### PR TITLE
Throw exception when connection is null

### DIFF
--- a/lib/src/main/kotlin/com/babylon/certificatetransparency/internal/verifier/CertificateTransparencyInterceptor.kt
+++ b/lib/src/main/kotlin/com/babylon/certificatetransparency/internal/verifier/CertificateTransparencyInterceptor.kt
@@ -42,9 +42,12 @@ internal class CertificateTransparencyInterceptor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val host = chain.request().url().host()
-        val certs = chain.connection()?.handshake()?.peerCertificates() ?: emptyList()
+        val connection = chain.connection()
+            ?: throw IllegalStateException("No connection found. Verify interceptor is added using addNetworkInterceptor")
 
-        val result = if (chain.connection()?.socket() is SSLSocket) {
+        val certs = connection.handshake()?.peerCertificates() ?: emptyList()
+
+        val result = if (connection.socket() is SSLSocket) {
             verifyCertificateTransparency(host, certs)
         } else {
             VerificationResult.Success.InsecureConnection(host)

--- a/lib/src/test/kotlin/com/babylon/certificatetransparency/internal/CertificateTransparencyInterceptorIntegrationTest.kt
+++ b/lib/src/test/kotlin/com/babylon/certificatetransparency/internal/CertificateTransparencyInterceptorIntegrationTest.kt
@@ -123,4 +123,15 @@ class CertificateTransparencyInterceptorIntegrationTest {
 
         client.newCall(request).execute()
     }
+
+    @Test(expected = IllegalStateException::class)
+    fun interceptorThrowsException() {
+        val client = OkHttpClient.Builder().addInterceptor(networkInterceptor).build()
+
+        val request = Request.Builder()
+            .url("https://www.babylonhealth.com")
+            .build()
+
+        client.newCall(request).execute()
+    }
 }


### PR DESCRIPTION
To help reduce the chance of mis-configuration of the interceptor, for example see issue #22, if no connection is found then throw an illegalstateexception is thrown.

